### PR TITLE
Support accessing exception messages

### DIFF
--- a/core-java/src/main/antlr/org/xtuml/masl/antlr/MaslP.g
+++ b/core-java/src/main/antlr/org/xtuml/masl/antlr/MaslP.g
@@ -1127,12 +1127,16 @@ variableDeclaration           : variableName COLON
                               ;
 
 
-exceptionHandler              : WHEN qualifiedExceptionName GOES_TO statementList         -> ^( EXCEPTION_HANDLER 
+exceptionHandler              : WHEN qualifiedExceptionName
+                                (WITH variableName)? GOES_TO statementList                -> ^( EXCEPTION_HANDLER 
                                                                                                 qualifiedExceptionName 
+                                                                                                variableName?
                                                                                                 statementList)
                               ;
 
-otherHandler                  : WHEN OTHERS GOES_TO statementList                         -> ^( OTHER_HANDLER[$OTHERS] 
+otherHandler                  : WHEN OTHERS
+                                (WITH variableName)? GOES_TO statementList                -> ^( OTHER_HANDLER[$OTHERS] 
+                                                                                                variableName?
                                                                                                 statementList)
                               ;
 

--- a/core-java/src/main/antlr/org/xtuml/masl/antlr/Walker.g
+++ b/core-java/src/main/antlr/org/xtuml/masl/antlr/Walker.g
@@ -1873,8 +1873,14 @@ returns [VariableDefinition var]
 
 exceptionHandler
 returns [ExceptionHandler handler]
+scope NameScope;
                               : ^( EXCEPTION_HANDLER
-                                   exceptionReference       { $handler = ExceptionHandler.create ( $exceptionReference.ref ); }
+                                   exceptionReference
+                                   variableName?            { $handler = ExceptionHandler.create ( $exceptionReference.ref, $variableName.name );
+                                                              if ( $variableName.name != null ) {
+                                                                $NameScope::lookup = $handler.getNameLookup();
+                                                              }
+                                                            }
                                    ^(STATEMENT_LIST ( statement              { if ( $handler != null ) $handler.addStatement($statement.st); } 
                                    )* )
                                  )
@@ -1882,7 +1888,12 @@ returns [ExceptionHandler handler]
 
 otherHandler
 returns [ExceptionHandler handler]
-                              : ^( OTHER_HANDLER            { $handler = ExceptionHandler.create( getPosition($OTHER_HANDLER) ); }
+                              : ^( OTHER_HANDLER
+                                   variableName?            { $handler = ExceptionHandler.create ( getPosition($OTHER_HANDLER), $variableName.name );
+                                                              if ( $variableName.name != null ) {
+                                                                $NameScope::lookup = $handler.getNameLookup();
+                                                              }
+                                                            }
                                    ^(STATEMENT_LIST ( statement              { if ( $handler != null ) $handler.addStatement($statement.st); }
                                    )* )
                                  )

--- a/core-java/src/main/java/org/xtuml/masl/metamodel/code/ExceptionHandler.java
+++ b/core-java/src/main/java/org/xtuml/masl/metamodel/code/ExceptionHandler.java
@@ -20,4 +20,8 @@ public interface ExceptionHandler
   ExceptionReference getException ();
 
   List<? extends Statement> getCode ();
+
+  String getMessageVariable ();
+
+  VariableDefinition getMessageVarDef ();
 }

--- a/core-java/src/main/java/org/xtuml/masl/translate/main/code/CodeBlockTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/main/code/CodeBlockTranslator.java
@@ -10,16 +10,21 @@ import java.util.List;
 
 import org.xtuml.masl.cppgen.Class;
 import org.xtuml.masl.cppgen.CodeBlock;
+import org.xtuml.masl.cppgen.CodeBlock;
+import org.xtuml.masl.cppgen.Literal;
 import org.xtuml.masl.cppgen.StatementGroup;
 import org.xtuml.masl.cppgen.TryCatchBlock;
 import org.xtuml.masl.cppgen.TypeUsage;
 import org.xtuml.masl.cppgen.Variable;
+import org.xtuml.masl.cppgen.VariableDefinitionStatement;
 import org.xtuml.masl.metamodel.code.ExceptionHandler;
 import org.xtuml.masl.metamodel.code.VariableDefinition;
 import org.xtuml.masl.metamodel.exception.ExceptionReference;
 import org.xtuml.masl.translate.main.Architecture;
 import org.xtuml.masl.translate.main.ExceptionTranslator;
+import org.xtuml.masl.translate.main.Mangler;
 import org.xtuml.masl.translate.main.Scope;
+import org.xtuml.masl.translate.main.Types;
 
 
 
@@ -83,6 +88,15 @@ public class CodeBlockTranslator extends CodeTranslator
     {
       this.handler = handler;
       codeBlock.appendStatement(preamble);
+
+      final VariableDefinition maslMessageVar = handler.getMessageVarDef();
+      if (maslMessageVar != null)
+      {
+        final TypeUsage type = Types.getInstance().getType(maslMessageVar.getType());
+        final Variable messageVar = new Variable(type.getConstType(), Mangler.mangleName(maslMessageVar), new Literal("exception.what()"));
+        getScope().addVariable(maslMessageVar, messageVar.asExpression());
+        codeBlock.appendStatement(new VariableDefinitionStatement(messageVar));
+      }
 
       for ( final org.xtuml.masl.metamodel.code.Statement maslStatement : handler.getCode() )
       {


### PR DESCRIPTION
MASL has long supported passing an optional string message when raising
an exception in action language. This change allows a modeler to define
a local variable which can be used to access the string description of
the exception (including the call stack)