### PR TITLE
Kafka MASL updates

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -4,14 +4,16 @@ set -e
 base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function masl-dev {
-	docker compose -f ${base_dir}/docker/docker-compose.yml run -e ARTIFACTORY_USERNAME=${ARTIFACTORY_USERNAME} -e ARTIFACTORY_TOKEN=${ARTIFACTORY_TOKEN} -e MASL_VERSION=$(git describe --tags) --rm -v $PWD:/work masl-dev "$@"
+	docker compose -f ${base_dir}/docker/docker-compose.yml run -e ARTIFACTORY_USERNAME=${ARTIFACTORY_USERNAME} -e ARTIFACTORY_TOKEN=${ARTIFACTORY_TOKEN} --rm -v $PWD:/work masl-dev "$@"
 }
 
-(cd conan-helper && masl-dev conan-publish)
-(cd conan-helper && masl-dev conan-publish)
-(cd core-cpp && masl-dev conan-publish)
-(cd core-java && masl-dev conan-publish)
-(cd utils && masl-dev conan-publish)
-(cd inspector && masl-dev conan-publish)
-# (cd examples/petrol && masl-dev  conan-publish) LPS not working
-(cd examples/calculator && masl-dev conan-publish)
+VERSION=$(git describe --tags)
+
+(cd conan-helper && masl-dev conan-publish --version=${VERSION})
+(cd conan-helper && masl-dev conan-publish --version=${VERSION})
+(cd core-cpp && masl-dev conan-publish --version=${VERSION})
+(cd core-java && masl-dev conan-publish --version=${VERSION})
+(cd utils && masl-dev conan-publish --version=${VERSION})
+(cd inspector && masl-dev conan-publish --version=${VERSION})
+# (cd examples/petrol && masl-dev  conan-publish --version=${VERSION}) LPS not working
+(cd examples/calculator && masl-dev conan-publish --version=${VERSION})

--- a/core-cpp/kafka/include/kafka/Consumer.hh
+++ b/core-cpp/kafka/include/kafka/Consumer.hh
@@ -1,6 +1,7 @@
 #ifndef Kafka_Consumer_HH
 #define Kafka_Consumer_HH
 
+#include "cppkafka/consumer.h"
 #include "cppkafka/message.h"
 
 #include <condition_variable>
@@ -35,6 +36,8 @@ private:
   MessageQueue messageQueue;
 
   void handleMessage();
+
+  void createTopics(cppkafka::Consumer& consumer, std::vector<std::string> topics);
 };
 
 } // namespace Kafka

--- a/core-cpp/kafka/include/kafka/Consumer.hh
+++ b/core-cpp/kafka/include/kafka/Consumer.hh
@@ -19,6 +19,8 @@ class MessageQueue {
 public:
   void enqueue(cppkafka::Message &msg);
   Message dequeue();
+  std::vector<Message> dequeue_all();
+  bool empty() { return queue.empty(); }
 
 private:
   std::queue<Message> queue;
@@ -35,7 +37,7 @@ public:
 private:
   MessageQueue messageQueue;
 
-  void handleMessage();
+  void handleMessages();
 
   void createTopics(cppkafka::Consumer& consumer, std::vector<std::string> topics);
 };

--- a/core-cpp/kafka/include/kafka/ProcessHandler.hh
+++ b/core-cpp/kafka/include/kafka/ProcessHandler.hh
@@ -23,13 +23,20 @@ public:
 
   bool hasRegisteredServices() { return serviceLookup.size() > 0; }
 
-  static std::string getTopicName(int domainId, int serviceId);
+  bool setCustomTopicName(int domainId, int serviceId, std::string topicName);
+
+  std::string getTopicName(int domainId, int serviceId);
 
   static ProcessHandler &getInstance();
 
+
+
 private:
   typedef std::map<std::string, std::shared_ptr<ServiceHandler>> ServiceLookup;
+  typedef std::map<std::pair<int, int>, std::string> TopicMap;
+
   ServiceLookup serviceLookup;
+  TopicMap customTopicNames;
 };
 
 } // namespace Kafka

--- a/core-cpp/kafka/include/kafka/Producer.hh
+++ b/core-cpp/kafka/include/kafka/Producer.hh
@@ -12,7 +12,7 @@ class Producer {
 
 public:
   Producer();
-  void publish(int domainId, int serviceId, BufferedOutputStream &buf);
+  void publish(int domainId, int serviceId, BufferedOutputStream &buf, BufferedOutputStream &partKey);
   static Producer &getInstance();
 
 private:

--- a/core-cpp/kafka/src/Consumer.cc
+++ b/core-cpp/kafka/src/Consumer.cc
@@ -5,12 +5,13 @@
 #include "kafka/ProcessHandler.hh"
 
 #include "swa/CommandLine.hh"
+#include "swa/Duration.hh"
 #include "swa/Process.hh"
+#include "swa/ProgramError.hh"
 #include "swa/RealTimeSignalListener.hh"
 
 #include "cppkafka/buffer.h"
 #include "cppkafka/configuration.h"
-#include "cppkafka/consumer.h"
 #include "cppkafka/utils/consumer_dispatcher.h"
 
 #include <uuid/uuid.h>
@@ -40,6 +41,12 @@ void Consumer::run() {
 
   // Create the consumer
   cppkafka::Consumer consumer(config);
+
+  // create topics if they don't already exist
+  createTopics(consumer, ProcessHandler::getInstance().getTopicNames());
+
+  // short delay to avoid race conditions if other processes initiated topic creation
+  SWA::delay(SWA::Duration::fromMillis(100));
 
   // Subscribe to topics
   consumer.subscribe(ProcessHandler::getInstance().getTopicNames());
@@ -86,6 +93,76 @@ void Consumer::handleMessage() {
     service();
   } catch (std::out_of_range &e) {
     // the queue is empty
+  }
+}
+
+void Consumer::createTopics(cppkafka::Consumer& consumer, std::vector<std::string> topics) {
+  // TODO clean up error handling in this routine
+  for (auto it = topics.begin(); it != topics.end(); it++) {
+
+    const char* topicname = (*it).data();
+    int partition_cnt = 1;
+    int replication_factor = 1;
+
+    rd_kafka_t *rk = consumer.get_handle();
+    rd_kafka_NewTopic_t *newt[1];
+    const size_t newt_cnt = 1;
+    rd_kafka_AdminOptions_t *options;
+    rd_kafka_queue_t *rkqu;
+    rd_kafka_event_t *rkev;
+    const rd_kafka_CreateTopics_result_t *res;
+    const rd_kafka_topic_result_t **terr;
+    int timeout_ms = 10000;
+    size_t res_cnt;
+    rd_kafka_resp_err_t err;
+    char errstr[512];
+
+    rkqu = rd_kafka_queue_new(rk);
+
+    newt[0] = rd_kafka_NewTopic_new(topicname, partition_cnt, replication_factor, errstr, sizeof(errstr));
+
+    if (newt[0] == NULL) {
+      throw SWA::ProgramError(errstr);
+    }
+
+    options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_CREATETOPICS);
+    err = rd_kafka_AdminOptions_set_operation_timeout(options, timeout_ms, errstr, sizeof(errstr));
+
+    if (err) {
+      throw SWA::ProgramError(errstr);
+    }
+
+    rd_kafka_CreateTopics(rk, newt, newt_cnt, options, rkqu);
+
+    /* Wait for result */
+    rkev = rd_kafka_queue_poll(rkqu, timeout_ms + 2000);
+
+
+    if (rd_kafka_event_error(rkev)) {
+      throw SWA::ProgramError(rd_kafka_event_error_string(rkev));
+    }
+
+    res = rd_kafka_event_CreateTopics_result(rkev);
+
+    terr = rd_kafka_CreateTopics_result_topics(res, &res_cnt);
+
+    if (!terr) {
+      throw SWA::ProgramError("terr is null");
+    }
+
+    if (res_cnt != newt_cnt) {
+      throw SWA::ProgramError("res_cnt != newt_cnt");
+    }
+
+    if (rd_kafka_topic_result_error(terr[0]) && rd_kafka_topic_result_error(terr[0]) != RD_KAFKA_RESP_ERR_TOPIC_ALREADY_EXISTS) {
+      throw SWA::ProgramError(std::string(rd_kafka_topic_result_name(terr[0])) + ": " + std::string(rd_kafka_topic_result_error_string(terr[0])));
+    }
+
+    rd_kafka_event_destroy(rkev);
+    rd_kafka_queue_destroy(rkqu);
+    rd_kafka_AdminOptions_destroy(options);
+    rd_kafka_NewTopic_destroy(newt[0]);
+
   }
 }
 

--- a/core-cpp/kafka/src/ProcessHandler.cc
+++ b/core-cpp/kafka/src/ProcessHandler.cc
@@ -37,14 +37,29 @@ std::vector<std::string> ProcessHandler::getTopicNames() {
   return topicNames;
 }
 
+bool ProcessHandler::setCustomTopicName(int domainId, int serviceId, std::string topicName) {
+  std::pair<int, int> key (domainId, serviceId);
+  customTopicNames.insert(TopicMap::value_type(key, topicName));
+  return true;
+}
+
 std::string ProcessHandler::getTopicName(int domainId, int serviceId) {
-  static const std::string ns = SWA::CommandLine::getInstance().getOption(NamespaceOption);
-  if (ns.empty()) {
-    return SWA::Process::getInstance().getDomain(domainId).getName() + "_service" + std::to_string(serviceId);
+  std::string name = "";
+
+  // get the base name
+  std::pair<int, int> key (domainId, serviceId);
+  if (customTopicNames.contains(key)) {
+    name = customTopicNames[key];
   } else {
-    return ns + "." + SWA::Process::getInstance().getDomain(domainId).getName() + "_service" + std::to_string(serviceId);
+    name = SWA::Process::getInstance().getDomain(domainId).getName() + "_service" + std::to_string(serviceId);
   }
 
+  // add the namespace if applicable
+  static const std::string ns = SWA::CommandLine::getInstance().getOption(NamespaceOption);
+  if (!ns.empty()) {
+    name = ns + "." + name;
+  }
+  return name;
 }
 
 ProcessHandler &ProcessHandler::getInstance() {

--- a/core-cpp/kafka/src/ProcessHandler.cc
+++ b/core-cpp/kafka/src/ProcessHandler.cc
@@ -38,8 +38,13 @@ std::vector<std::string> ProcessHandler::getTopicNames() {
 }
 
 std::string ProcessHandler::getTopicName(int domainId, int serviceId) {
-  static const std::string ns = SWA::CommandLine::getInstance().getOption(NamespaceOption, "default");
-  return ns + "." + SWA::Process::getInstance().getDomain(domainId).getName() + "_service" + std::to_string(serviceId);
+  static const std::string ns = SWA::CommandLine::getInstance().getOption(NamespaceOption);
+  if (ns.empty()) {
+    return SWA::Process::getInstance().getDomain(domainId).getName() + "_service" + std::to_string(serviceId);
+  } else {
+    return ns + "." + SWA::Process::getInstance().getDomain(domainId).getName() + "_service" + std::to_string(serviceId);
+  }
+
 }
 
 ProcessHandler &ProcessHandler::getInstance() {

--- a/core-cpp/kafka/src/Producer.cc
+++ b/core-cpp/kafka/src/Producer.cc
@@ -16,7 +16,7 @@ Producer::Producer() {
   prod = std::unique_ptr<cppkafka::Producer>(new cppkafka::Producer(config));
 }
 
-void Producer::publish(int domainId, int serviceId, BufferedOutputStream &buf) {
+void Producer::publish(int domainId, int serviceId, BufferedOutputStream &buf, BufferedOutputStream &partKey) {
   // find/create a message builder
   std::shared_ptr<cppkafka::MessageBuilder> msgBuilder;
   TopicLookup::iterator entry = topicLookup.find(std::make_pair(domainId, serviceId));
@@ -27,6 +27,11 @@ void Producer::publish(int domainId, int serviceId, BufferedOutputStream &buf) {
         std::make_pair(domainId, serviceId), msgBuilder));
   } else {
     msgBuilder = entry->second;
+  }
+
+  // set the partion key
+  if (partKey.begin() != partKey.end()) {
+    msgBuilder->key(cppkafka::Buffer(partKey.begin(), partKey.end()));
   }
 
   // Set the payload on this builder

--- a/core-cpp/kafka/src/Producer.cc
+++ b/core-cpp/kafka/src/Producer.cc
@@ -21,7 +21,7 @@ void Producer::publish(int domainId, int serviceId, BufferedOutputStream &buf, B
   std::shared_ptr<cppkafka::MessageBuilder> msgBuilder;
   TopicLookup::iterator entry = topicLookup.find(std::make_pair(domainId, serviceId));
   if (entry == topicLookup.end()) {
-    std::string topicName = ProcessHandler::getTopicName(domainId, serviceId);
+    std::string topicName = ProcessHandler::getInstance().getTopicName(domainId, serviceId);
     msgBuilder = std::shared_ptr<cppkafka::MessageBuilder>(new cppkafka::MessageBuilder(topicName));
     topicLookup.insert(TopicLookup::value_type(
         std::make_pair(domainId, serviceId), msgBuilder));

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTranslator.java
@@ -19,6 +19,9 @@ import org.xtuml.masl.translate.main.Mangler;
 public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator
 {
 
+  public static final String KAFKA_TOPIC_PRAGMA = "kafka_topic";
+  public static final String KAFKA_PARTITION_KEY_PRAGMA = "kafka_partition_key";
+
   private final org.xtuml.masl.translate.main.DomainTranslator mainTranslator;
   private final Namespace domainNamespace;
   private final Library library;
@@ -61,7 +64,7 @@ public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator
 
     // create service translators
     final List<ServiceTranslator> serviceTranslators = domain.getServices().stream()
-      .filter(service -> service.getDeclarationPragmas().hasPragma("kafka_topic") && !service.isFunction() && !service.isExternal() && !service.isScenario())
+      .filter(service -> service.getDeclarationPragmas().hasPragma(KAFKA_TOPIC_PRAGMA) && !service.isFunction() && !service.isExternal() && !service.isScenario())
       .map(service -> new ServiceTranslator(service, this)).collect(Collectors.toList());
 
 

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTranslator.java
@@ -74,6 +74,12 @@ public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator
       serviceTranslator.addServiceHandler(consumerCodeFile);
     }
 
+    // handle custom topics (consumer)
+    for (final ServiceTranslator serviceTranslator : serviceTranslators)
+    {
+      serviceTranslator.addCustomTopicName(consumerCodeFile);
+    }
+
     // add topic registrations
     for (final ServiceTranslator serviceTranslator : serviceTranslators)
     {
@@ -84,6 +90,12 @@ public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator
     for (final ServiceTranslator serviceTranslator : serviceTranslators)
     {
       serviceTranslator.addPublisher(publisherCodeFile);
+    }
+
+    // handle custom topics (publisher)
+    for (final ServiceTranslator serviceTranslator : serviceTranslators)
+    {
+      serviceTranslator.addCustomTopicName(publisherCodeFile);
     }
 
     // process type readers/writers

--- a/core-java/src/main/java/org/xtuml/masl/translate/main/DomainTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/main/DomainTranslator.java
@@ -40,6 +40,7 @@ import org.xtuml.masl.translate.building.FileGroup;
 import org.xtuml.masl.translate.main.object.ObjectTranslator;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Alias("Main")
 @Default
@@ -407,7 +408,7 @@ public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator 
         servicesEnum = new EnumerationType("ServiceIds", DomainNamespace.get(domain));
         interfaceDomainHeader.addEnumerateDeclaration(servicesEnum);
 
-        for (final DomainService service : domain.getServices()) {
+        for (final DomainService service : domain.getServices().stream().sorted(Comparator.comparing(DomainService::getName)).collect(Collectors.toList())) {
             final String enumName = "serviceId_" + Mangler.mangleName(service);
             final Enumerator serviceId = servicesEnum.addEnumerator(enumName, null);
 

--- a/docker/masl-dev/os-files/usr/local/bin/conan-publish
+++ b/docker/masl-dev/os-files/usr/local/bin/conan-publish
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 pid=$$
-conan create . --version ${MASL_VERSION} --format=json --build=missing "$@" >/tmp/${pid}_create.json
+conan create . --format=json --build=missing "$@" >/tmp/${pid}_create.json
 conan list --graph=/tmp/${pid}_create.json --graph-binaries=build --format=json >/tmp/${pid}_pkglist.json
 (conan remote login -p ${ARTIFACTORY_TOKEN} xtuml ${ARTIFACTORY_USERNAME} &&
 	conan upload --list=/tmp/${pid}_pkglist.json -r=xtuml -c) ||


### PR DESCRIPTION
- Added ability to set a list of parameters to serve as the partition key for the Kafka topic
- Changed the default namespace to be blank for more readable topic names
- Support custom topic names in the pragma
- Automatically create topics on startup (if they don't exist)
- Sort domain services in the generated enum for consistency across platforms
- Change to the polling mechanism to prevent starving the event loop
- Update to the publish script to make more reusable