### PR TITLE
Don't set test code in terminator service constructor

### DIFF
--- a/core-java/src/main/java/org/xtuml/masl/metamodelImpl/domain/DomainTerminatorService.java
+++ b/core-java/src/main/java/org/xtuml/masl/metamodelImpl/domain/DomainTerminatorService.java
@@ -155,9 +155,6 @@ public class DomainTerminatorService extends Service
                                            true,
                                            createExpression,
                                            new PragmaList());
-            final CodeBlock code = new CodeBlock(position, true);
-            code.addVariableDefinition(testInstance);
-            super.setCode(code);
         }
 
     }


### PR DESCRIPTION
In test mode DomainTerminatorService creates an instance of the call mock as a 'declare' variable. This gets added to the code block in setCode(), but previously it was also doing this in the constructor by creating a blank code block which would later get overridden. This empty code block was then being validated by super().setCode(), and obviously failing for functions as there was no return. At one time we allowed the .tr files to be omitted in domains, as they should be overridden in the .prj if not present, so setCode would never have been called in this case, hence having to put a default in in the constructor. But .tr files must be there now, so no need for that.
