### PR TITLE
Implement polled kafka topics

### DIFF
--- a/core-cpp/kafka/CMakeLists.txt
+++ b/core-cpp/kafka/CMakeLists.txt
@@ -9,6 +9,7 @@ simple_add_shared_library (
   NAME      Kafka
   SOURCES
             Consumer.cc
+            DataConsumer.cc
             Kafka.cc
             ProcessHandler.cc
             Producer.cc
@@ -24,6 +25,7 @@ simple_add_shared_library (
   EXPORT    MaslCore
   INCLUDES
             kafka/Consumer.hh
+            kafka/DataConsumer.hh
             kafka/Kafka.hh
             kafka/ProcessHandler.hh
             kafka/Producer.hh

--- a/core-cpp/kafka/include/kafka/Consumer.hh
+++ b/core-cpp/kafka/include/kafka/Consumer.hh
@@ -29,15 +29,16 @@ private:
 class Consumer {
 
 public:
+  Consumer(std::vector<std::string> topics);
   void run();
-  static Consumer &getInstance();
 
 private:
   MessageQueue messageQueue;
+  std::unique_ptr<cppkafka::Consumer> consumer;
 
-  void handleMessages(cppkafka::Consumer& consumer);
+  void handleMessages();
 
-  void createTopics(cppkafka::Consumer& consumer, std::vector<std::string> topics);
+  void createTopics(std::vector<std::string> topics);
 };
 
 } // namespace Kafka

--- a/core-cpp/kafka/include/kafka/Consumer.hh
+++ b/core-cpp/kafka/include/kafka/Consumer.hh
@@ -4,6 +4,8 @@
 #include "cppkafka/consumer.h"
 #include "cppkafka/message.h"
 
+#include "DataConsumer.hh"
+
 #include <condition_variable>
 #include <mutex>
 #include <queue>
@@ -29,15 +31,17 @@ private:
 class Consumer {
 
 public:
+  Consumer(std::string topic);
   Consumer(std::vector<std::string> topics);
+  bool consumeOne(DataConsumer& dataConsumer);
   void run();
 
 private:
   MessageQueue messageQueue;
   std::unique_ptr<cppkafka::Consumer> consumer;
 
+  void initialize(std::vector<std::string> topics);
   void handleMessages();
-
   void createTopics(std::vector<std::string> topics);
 };
 

--- a/core-cpp/kafka/include/kafka/DataConsumer.hh
+++ b/core-cpp/kafka/include/kafka/DataConsumer.hh
@@ -1,0 +1,18 @@
+#ifndef Kafka_DataConsumer_HH
+#define Kafka_DataConsumer_HH
+
+#include <cstdint>
+#include <vector>
+
+namespace Kafka {
+
+class DataConsumer {
+public:
+  virtual void accept(std::vector<std::uint8_t> data) const {
+  }
+  virtual ~DataConsumer();
+};
+
+} // namespace Kafka
+
+#endif

--- a/core-cpp/kafka/include/kafka/Kafka.hh
+++ b/core-cpp/kafka/include/kafka/Kafka.hh
@@ -6,6 +6,8 @@ namespace Kafka {
 extern const char *const BrokersOption;
 extern const char *const GroupIdOption;
 extern const char *const NamespaceOption;
+extern const char *const NamespaceOption;
+extern const char *const OffsetResetOption;
 
 }
 

--- a/core-cpp/kafka/include/kafka/ProcessHandler.hh
+++ b/core-cpp/kafka/include/kafka/ProcessHandler.hh
@@ -27,6 +27,8 @@ public:
 
   std::string getTopicName(int domainId, int serviceId);
 
+  void startConsumer();
+
   static ProcessHandler &getInstance();
 
 

--- a/core-cpp/kafka/include/kafka/Producer.hh
+++ b/core-cpp/kafka/include/kafka/Producer.hh
@@ -12,6 +12,7 @@ class Producer {
 
 public:
   Producer();
+  void publish(int domainId, int serviceId, std::vector<std::uint8_t> data, std::vector<std::uint8_t> partKey);
   void publish(int domainId, int serviceId, std::string data, std::string partKey);
   static Producer &getInstance();
 
@@ -20,6 +21,7 @@ private:
   typedef std::map<ServiceKey, std::shared_ptr<cppkafka::MessageBuilder>> TopicLookup;
   TopicLookup topicLookup;
   std::unique_ptr<cppkafka::Producer> prod;
+  void publish(int domainId, int serviceId, cppkafka::Buffer& data, cppkafka::Buffer& partKey);
 };
 
 } // namespace Kafka

--- a/core-cpp/kafka/include/kafka/Producer.hh
+++ b/core-cpp/kafka/include/kafka/Producer.hh
@@ -1,8 +1,6 @@
 #ifndef Kafka_Producer_HH
 #define Kafka_Producer_HH
 
-#include <nlohmann/json.hpp>
-
 #include "cppkafka/message_builder.h"
 #include "cppkafka/producer.h"
 

--- a/core-cpp/kafka/include/kafka/ServiceHandler.hh
+++ b/core-cpp/kafka/include/kafka/ServiceHandler.hh
@@ -10,7 +10,7 @@ typedef std::function<void()> Callable;
 
 class ServiceHandler {
 public:
-  virtual Callable getInvoker(std::string data) const {
+  virtual Callable getInvoker(std::vector<std::uint8_t> data) const {
     return Callable();
   }
   virtual ~ServiceHandler();

--- a/core-cpp/kafka/include/kafka/ServiceHandler.hh
+++ b/core-cpp/kafka/include/kafka/ServiceHandler.hh
@@ -1,8 +1,9 @@
 #ifndef Kafka_ServiceHandler_HH
 #define Kafka_ServiceHandler_HH
 
-#include <nlohmann/json.hpp>
+#include <cstdint>
 #include <functional>
+#include <vector>
 
 namespace Kafka {
 

--- a/core-cpp/kafka/src/Consumer.cc
+++ b/core-cpp/kafka/src/Consumer.cc
@@ -90,7 +90,7 @@ void Consumer::handleMessages(cppkafka::Consumer& consumer) {
       // TODO maybe this is the right spot to handle errors and check conditions on the msg instance?
 
       // get the service invoker
-      Callable service = ProcessHandler::getInstance().getServiceHandler(msg.get_topic()).getInvoker(std::string(msg.get_payload()));
+      Callable service = ProcessHandler::getInstance().getServiceHandler(msg.get_topic()).getInvoker(std::vector<uint8_t>(msg.get_payload()));
 
       // run the service
       service();

--- a/core-cpp/kafka/src/Consumer.cc
+++ b/core-cpp/kafka/src/Consumer.cc
@@ -21,6 +21,7 @@ void Consumer::run() {
 
   // Get command line options
   const std::string brokers = SWA::CommandLine::getInstance().getOption(BrokersOption);
+  const std::string offsetReset = SWA::CommandLine::getInstance().getOption(OffsetResetOption, "earliest");
 
   std::string groupId;
   if (SWA::CommandLine::getInstance().optionPresent(GroupIdOption)) {
@@ -37,6 +38,7 @@ void Consumer::run() {
   // Construct the configuration
   cppkafka::Configuration config = {{"metadata.broker.list", brokers},
                                     {"group.id", groupId},
+                                    {"auto.offset.reset", offsetReset},
                                     {"enable.auto.commit", false}};
 
   // Create the consumer

--- a/core-cpp/kafka/src/DataConsumer.cc
+++ b/core-cpp/kafka/src/DataConsumer.cc
@@ -1,0 +1,7 @@
+#include "kafka/DataConsumer.hh"
+
+namespace Kafka {
+
+DataConsumer::~DataConsumer() {}
+
+} // namespace Kafka

--- a/core-cpp/kafka/src/Kafka.cc
+++ b/core-cpp/kafka/src/Kafka.cc
@@ -20,7 +20,7 @@ const char *const OffsetResetOption = "-kafka-offset-reset";
 bool startup() {
   if (ProcessHandler::getInstance().hasRegisteredServices()) {
     // only start the consumer if there are registered services
-    std::thread{[] { Consumer::getInstance().run(); }}.detach();
+    std::thread{[] { ProcessHandler::getInstance().startConsumer(); }}.detach();
   }
 
   return true;

--- a/core-cpp/kafka/src/Kafka.cc
+++ b/core-cpp/kafka/src/Kafka.cc
@@ -12,9 +12,10 @@
 
 namespace Kafka {
 
-const char *const BrokersOption   = "-kafka-broker-list";
-const char *const GroupIdOption   = "-kafka-group-id";
-const char *const NamespaceOption = "-kafka-namespace";
+const char *const BrokersOption     = "-kafka-broker-list";
+const char *const GroupIdOption     = "-kafka-group-id";
+const char *const NamespaceOption   = "-kafka-namespace";
+const char *const OffsetResetOption = "-kafka-offset-reset";
 
 bool startup() {
   if (ProcessHandler::getInstance().hasRegisteredServices()) {
@@ -35,6 +36,7 @@ struct Init {
     SWA::CommandLine::getInstance().registerOption(SWA::NamedOption(BrokersOption, std::string("Kafka Brokers"), true, "brokerList", true, false));
     SWA::CommandLine::getInstance().registerOption(SWA::NamedOption(GroupIdOption, std::string("Kafka Group ID"), false, "groupId", true, false));
     SWA::CommandLine::getInstance().registerOption(SWA::NamedOption(NamespaceOption, std::string("Kafka Topic Namespace"), false, "namespace", true, false));
+    SWA::CommandLine::getInstance().registerOption(SWA::NamedOption(OffsetResetOption, std::string("Consumer Offset Reset Policy"), false, "offset", true, false));
 
     SWA::Process::getInstance().registerStartedListener(&startup);
   }

--- a/core-cpp/kafka/src/ProcessHandler.cc
+++ b/core-cpp/kafka/src/ProcessHandler.cc
@@ -1,6 +1,7 @@
 #include "kafka/ProcessHandler.hh"
 
 #include "kafka/Kafka.hh"
+#include "kafka/Consumer.hh"
 
 #include "swa/CommandLine.hh"
 #include "swa/Process.hh"
@@ -60,6 +61,11 @@ std::string ProcessHandler::getTopicName(int domainId, int serviceId) {
     name = ns + "." + name;
   }
   return name;
+}
+
+void ProcessHandler::startConsumer() {
+  Consumer consumer(getTopicNames());
+  consumer.run();
 }
 
 ProcessHandler &ProcessHandler::getInstance() {

--- a/core-cpp/kafka/src/Producer.cc
+++ b/core-cpp/kafka/src/Producer.cc
@@ -16,7 +16,7 @@ Producer::Producer() {
   prod = std::unique_ptr<cppkafka::Producer>(new cppkafka::Producer(config));
 }
 
-void Producer::publish(int domainId, int serviceId, std::string data, std::string partKey) {
+void Producer::publish(int domainId, int serviceId, cppkafka::Buffer& data, cppkafka::Buffer& partKey) {
   // find/create a message builder
   std::shared_ptr<cppkafka::MessageBuilder> msgBuilder;
   TopicLookup::iterator entry = topicLookup.find(std::make_pair(domainId, serviceId));
@@ -30,7 +30,7 @@ void Producer::publish(int domainId, int serviceId, std::string data, std::strin
   }
 
   // set the partion key
-  if (!partKey.empty()) {
+  if (partKey.begin() != partKey.end()) {
     msgBuilder->key(partKey);
   }
 
@@ -39,6 +39,18 @@ void Producer::publish(int domainId, int serviceId, std::string data, std::strin
 
   // Produce the message
   prod->produce(*msgBuilder);
+}
+
+void Producer::publish(int domainId, int serviceId, std::vector<std::uint8_t> data, std::vector<std::uint8_t> partKey) {
+  cppkafka::Buffer dataBuffer = cppkafka::Buffer(data);
+  cppkafka::Buffer keyBuffer = cppkafka::Buffer(partKey);
+  publish(domainId, serviceId, dataBuffer, keyBuffer);
+}
+
+void Producer::publish(int domainId, int serviceId, std::string data, std::string partKey) {
+  cppkafka::Buffer dataBuffer = cppkafka::Buffer(data);
+  cppkafka::Buffer keyBuffer = cppkafka::Buffer(partKey);
+  publish(domainId, serviceId, dataBuffer, keyBuffer);
 }
 
 Producer &Producer::getInstance() {

--- a/core-java/.gitignore
+++ b/core-java/.gitignore
@@ -6,3 +6,7 @@ libs
 resources
 scripts
 tmp
+.classpath
+.project
+.settings/
+bin/

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainServiceTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainServiceTranslator.java
@@ -1,0 +1,271 @@
+package org.xtuml.masl.translate.kafka;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.xtuml.masl.cppgen.ArrayAccess;
+import org.xtuml.masl.cppgen.BinaryExpression;
+import org.xtuml.masl.cppgen.BinaryOperator;
+import org.xtuml.masl.cppgen.Class;
+import org.xtuml.masl.cppgen.CodeFile;
+import org.xtuml.masl.cppgen.DeclarationGroup;
+import org.xtuml.masl.cppgen.Expression;
+import org.xtuml.masl.cppgen.ExpressionStatement;
+import org.xtuml.masl.cppgen.Function;
+import org.xtuml.masl.cppgen.FunctionObjectCall;
+import org.xtuml.masl.cppgen.FundamentalType;
+import org.xtuml.masl.cppgen.Literal;
+import org.xtuml.masl.cppgen.NewExpression;
+import org.xtuml.masl.cppgen.ReturnStatement;
+import org.xtuml.masl.cppgen.Std;
+import org.xtuml.masl.cppgen.TypeUsage;
+import org.xtuml.masl.cppgen.TypedefType;
+import org.xtuml.masl.cppgen.Variable;
+import org.xtuml.masl.cppgen.VariableDefinitionStatement;
+import org.xtuml.masl.cppgen.Visibility;
+import org.xtuml.masl.metamodel.common.ParameterDefinition;
+import org.xtuml.masl.metamodel.domain.DomainService;
+import org.xtuml.masl.translate.main.Architecture;
+import org.xtuml.masl.translate.main.Mangler;
+import org.xtuml.masl.translate.main.NlohmannJson;
+import org.xtuml.masl.translate.main.ParameterTranslator;
+import org.xtuml.masl.translate.main.Types;
+
+public class DomainServiceTranslator extends ServiceTranslator {
+
+    private final CodeFile consumerCodeFile;
+    private final CodeFile publisherCodeFile;
+
+    private Class handlerClass;
+    private Class invokerClass;
+    private Function getInvokerFn;
+    private Variable topicNameSet;
+    private Variable consumerRegisteredVar;
+    private Variable publisherRegisteredVar;
+    private Function publishFn;
+
+    DomainServiceTranslator(DomainService service, DomainTranslator domainTranslator, CodeFile consumerCodeFile,
+            CodeFile publisherCodeFile) {
+        super(service, domainTranslator);
+        this.consumerCodeFile = consumerCodeFile;
+        this.publisherCodeFile = publisherCodeFile;
+    }
+
+    @Override
+    DomainService getService() {
+        return (DomainService) super.getService();
+    }
+
+    @Override
+    List<Runnable> getFilePopulators() {
+        return List.of(() -> consumerCodeFile.addClassDeclaration(handlerClass),
+                () -> consumerCodeFile.addClassDeclaration(invokerClass),
+                () -> consumerCodeFile.addFunctionDefinition(getInvokerFn),
+                topicNameSet != null ? () -> consumerCodeFile.addVariableDefinition(topicNameSet) : () -> {},
+                () -> consumerCodeFile.addVariableDefinition(consumerRegisteredVar),
+                () -> publisherCodeFile.addFunctionDefinition(publishFn),
+                topicNameSet != null ? () -> publisherCodeFile.addVariableDefinition(topicNameSet) : () -> {},
+                () -> publisherCodeFile.addVariableDefinition(publisherRegisteredVar));
+    }
+
+    @Override
+    void translate() {
+        translateConsumer();
+        translatePublisher();
+        translateCustomTopicName();
+    }
+
+    void translateConsumer() {
+        // create and add the handler class to the file
+        handlerClass = new Class(Mangler.mangleName(getService()) + "Handler", getDomainNamespace());
+        handlerClass.addSuperclass(Kafka.serviceHandlerClass, Visibility.PUBLIC);
+        final DeclarationGroup group = handlerClass.createDeclarationGroup();
+        getInvokerFn = handlerClass.createMemberFunction(group, "getInvoker", Visibility.PUBLIC);
+        getInvokerFn.setReturnType(new TypeUsage(Kafka.callable));
+        getInvokerFn.setConst(true);
+
+        // create the invoker class
+        invokerClass = new Class(Mangler.mangleName(getService()) + "Invoker", getDomainNamespace());
+        final DeclarationGroup functions = invokerClass.createDeclarationGroup();
+        final Function constructor = invokerClass.createConstructor(functions, Visibility.PUBLIC);
+        constructor.declareInClass(true);
+        final Expression paramData = constructor
+                .createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "param_data").asExpression();
+
+        // create invoker function
+        final Function invoker = invokerClass.createMemberFunction(functions, "operator()", Visibility.PUBLIC);
+        invoker.declareInClass(true);
+
+        // if the service has a single string parameter, just pass through
+        final boolean noParseJson = hasSingleStringParameter(getService());
+
+        // handle parameters
+        final List<Expression> invokeArgs = new ArrayList<>();
+        final DeclarationGroup vars = invokerClass.createDeclarationGroup();
+        final Variable paramJson = new Variable(new TypeUsage(NlohmannJson.json), "params",
+                NlohmannJson.parse(paramData));
+        if (!noParseJson && getService().getParameters().stream().map(p -> p.getType().getBasicType())
+                .anyMatch(ServiceTranslator::isTypeSerializable)) {
+            // Only build a JSON object if it will be used
+            constructor.getCode().appendStatement(new VariableDefinitionStatement(paramJson));
+        }
+        for (final ParameterDefinition param : getService().getParameters()) {
+            final TypeUsage type = Types.getInstance().getType(param.getType());
+            if (isTypeSerializable(param.getType().getBasicType())) {
+                final Variable arg = invokerClass.createMemberVariable(vars, Mangler.mangleName(param), type,
+                        Visibility.PRIVATE);
+                Expression paramAccess = Std.string.callConstructor(
+                        new Function("begin").asFunctionCall(paramData, false),
+                        new Function("end").asFunctionCall(paramData, false));
+                if (!noParseJson) {
+                    paramAccess = NlohmannJson.get(getService().getParameters().size() > 1
+                            ? new ArrayAccess(paramJson.asExpression(), Literal.createStringLiteral(param.getName()))
+                            : paramJson.asExpression(), type);
+                }
+                constructor.getCode().appendStatement(
+                        new BinaryExpression(arg.asExpression(), BinaryOperator.ASSIGN, paramAccess).asStatement());
+                invokeArgs.add(arg.asExpression());
+            } else {
+                final Variable arg = new Variable(type, Mangler.mangleName(param));
+                invoker.getCode().appendStatement(arg.asStatement());
+                invokeArgs.add(arg.asExpression());
+            }
+        }
+
+        // create the call to the service interceptor
+        final org.xtuml.masl.translate.main.DomainServiceTranslator serviceTranslator = org.xtuml.masl.translate.main.DomainServiceTranslator
+                .getInstance(getService());
+        final TypedefType serviceInterceptor = serviceTranslator.getServiceInterceptor();
+        final Function serviceFunction = new Function("callService");
+        final Expression instanceFnCall = serviceInterceptor.asClass().callStaticFunction("instance");
+        Expression invokeExpression = new FunctionObjectCall(serviceFunction.asFunctionCall(instanceFnCall, false),
+                invokeArgs);
+        invoker.getCode().appendStatement(invokeExpression.asStatement());
+
+        // add implementation of 'getInvoker' to the file
+        final Expression paramData2 = getInvokerFn
+                .createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "param_data").asExpression();
+        getInvokerFn.getCode().appendStatement(new ReturnStatement(invokerClass.callConstructor(paramData2)));
+
+        // void addTopicRegistration(final CodeFile codeFile) {
+        final Expression processHandler = Kafka.processHandlerClass.callStaticFunction("getInstance");
+        final Expression domainId = new Function("getId")
+                .asFunctionCall(new Function("getDomain").asFunctionCall(Architecture.process, false,
+                        Literal.createStringLiteral(getDomainTranslator().getDomain().getName())), false);
+        final Expression serviceId = org.xtuml.masl.translate.main.DomainServiceTranslator
+                .getInstance((DomainService) getService()).getServiceId();
+        final Expression handler = Std.shared_ptr(new TypeUsage(handlerClass))
+                .callConstructor(new NewExpression(new TypeUsage(handlerClass)));
+        final Function registerServiceFunc = new Function("registerServiceHandler");
+        final Expression registerService = registerServiceFunc.asFunctionCall(processHandler, false, domainId,
+                serviceId, handler);
+        consumerRegisteredVar = new Variable(new TypeUsage(FundamentalType.BOOL),
+                Mangler.mangleName(getService()) + "_registered", getDomainNamespace(), registerService);
+    }
+
+    void translatePublisher() {
+        // create service function
+        publishFn = new Function(Mangler.mangleName(getService()), getDomainNamespace());
+        publishFn.setReturnType(getDomainTranslator().getTypes().getType(getService().getReturnType()));
+
+        // if the service has a single string parameter, just pass through
+        final boolean noParseJson = hasSingleStringParameter(getService());
+
+        // create output buffer
+        final Variable paramData = new Variable(new TypeUsage(NlohmannJson.json), "param_data");
+        if (!noParseJson) {
+            // Only build a JSON object if it will be used
+            publishFn.getCode().appendStatement(new VariableDefinitionStatement(paramData));
+        }
+
+        // create partition key buffer
+        final Variable partKey = new Variable(new TypeUsage(NlohmannJson.json), "part_key");
+        final boolean includePartKey = getService().getParameters().stream().anyMatch(
+                param -> getService().getDeclarationPragmas().hasPragma(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA)
+                        && getService().getDeclarationPragmas()
+                                .getPragmaValues(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA)
+                                .contains(param.getName()));
+        if (includePartKey) {
+            publishFn.getCode().appendStatement(new VariableDefinitionStatement(partKey));
+        }
+
+        // handle parameters
+        final Map<ParameterDefinition, ParameterTranslator> paramTranslators = new HashMap<>();
+        for (final ParameterDefinition param : getService().getParameters()) {
+            final ParameterTranslator paramTrans = new ParameterTranslator(param, publishFn);
+            paramTranslators.put(param, paramTrans);
+            final Expression jsonAccess = getService().getParameters().size() > 1
+                    ? new ArrayAccess(paramData.asExpression(), Literal.createStringLiteral(param.getName()))
+                    : paramData.asExpression();
+            final Expression writeExpr = new BinaryExpression(jsonAccess, BinaryOperator.ASSIGN,
+                    paramTrans.getVariable().asExpression());
+            if (!noParseJson) {
+                publishFn.getCode().appendStatement(new ExpressionStatement(writeExpr));
+            }
+            if (getService().getDeclarationPragmas().hasPragma(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA)
+                    && getService().getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA)
+                            .contains(param.getName())) {
+                final Expression keyJsonAccess = getService().getDeclarationPragmas()
+                        .getPragmaValues(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA).size() > 1
+                                ? new ArrayAccess(partKey.asExpression(), Literal.createStringLiteral(param.getName()))
+                                : partKey.asExpression();
+                final Expression keyWriteExpr = new BinaryExpression(keyJsonAccess, BinaryOperator.ASSIGN,
+                        paramTrans.getVariable().asExpression());
+                publishFn.getCode().appendStatement(new ExpressionStatement(keyWriteExpr));
+            }
+        }
+
+        // call publisher
+        final Expression producer = Kafka.producerClass.callStaticFunction("getInstance");
+        final Function publishFunc = new Function("publish");
+        final Expression domainId = new Function("getId")
+                .asFunctionCall(new Function("getDomain").asFunctionCall(Architecture.process, false,
+                        Literal.createStringLiteral(getDomainTranslator().getDomain().getName())), false);
+        final Expression serviceId = org.xtuml.masl.translate.main.DomainServiceTranslator
+                .getInstance((DomainService) getService()).getServiceId();
+        final Expression publishExpr = publishFunc.asFunctionCall(producer, false, domainId, serviceId,
+                noParseJson
+                        ? Std.string.callConstructor(
+                                paramTranslators.get(getService().getParameters().get(0)).getVariable().asExpression())
+                        : NlohmannJson.dump(paramData.asExpression()),
+                includePartKey ? NlohmannJson.dump(partKey.asExpression()) : Literal.createStringLiteral(""));
+        publishFn.getCode().appendStatement(new ExpressionStatement(publishExpr));
+
+        // add service registration
+        final org.xtuml.masl.translate.main.DomainServiceTranslator serviceTranslator = org.xtuml.masl.translate.main.DomainServiceTranslator
+                .getInstance((DomainService) getService());
+        final TypedefType serviceInterceptor = serviceTranslator.getServiceInterceptor();
+        final Expression interceptorFnCall = serviceInterceptor.asClass().callStaticFunction("instance");
+        final Function registerFunction = new Function("registerLocal");
+        final Expression initialValue = registerFunction.asFunctionCall(interceptorFnCall, false,
+                publishFn.asFunctionPointer());
+        publisherRegisteredVar = new Variable(new TypeUsage(FundamentalType.BOOL, TypeUsage.Const),
+                "localServiceRegistration_" + Mangler.mangleName(getService()), getDomainNamespace(), initialValue);
+        publisherRegisteredVar.setStatic(true);
+    }
+
+    void translateCustomTopicName() {
+        if (getService().getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_TOPIC_PRAGMA).size() == 1) {
+            final String topicNameString = getService().getDeclarationPragmas()
+                    .getPragmaValues(DomainTranslator.KAFKA_TOPIC_PRAGMA).get(0);
+            if (!isBoolean(topicNameString) && !isNumeric(topicNameString)) {
+                final Expression processHandler = Kafka.processHandlerClass.callStaticFunction("getInstance");
+                final Expression domainId = new Function("getId")
+                        .asFunctionCall(
+                                new Function("getDomain").asFunctionCall(Architecture.process, false,
+                                        Literal.createStringLiteral(getDomainTranslator().getDomain().getName())),
+                                false);
+                final Expression serviceId = org.xtuml.masl.translate.main.DomainServiceTranslator
+                        .getInstance((DomainService) getService()).getServiceId();
+                final Expression topicName = Literal.createStringLiteral(topicNameString);
+                final Function setTopicNameFunc = new Function("setCustomTopicName");
+                final Expression setTopicName = setTopicNameFunc.asFunctionCall(processHandler, false, domainId,
+                        serviceId, topicName);
+                topicNameSet = new Variable(new TypeUsage(FundamentalType.BOOL),
+                        Mangler.mangleName(getService()) + "_topic_name_set", getDomainNamespace(), setTopicName);
+            }
+        }
+    }
+}

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTerminatorServiceTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTerminatorServiceTranslator.java
@@ -1,0 +1,156 @@
+package org.xtuml.masl.translate.kafka;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.xtuml.masl.cppgen.ArrayAccess;
+import org.xtuml.masl.cppgen.BinaryExpression;
+import org.xtuml.masl.cppgen.BinaryOperator;
+import org.xtuml.masl.cppgen.Class;
+import org.xtuml.masl.cppgen.CodeFile;
+import org.xtuml.masl.cppgen.DeclarationGroup;
+import org.xtuml.masl.cppgen.Expression;
+import org.xtuml.masl.cppgen.Function;
+import org.xtuml.masl.cppgen.FundamentalType;
+import org.xtuml.masl.cppgen.Literal;
+import org.xtuml.masl.cppgen.ReturnStatement;
+import org.xtuml.masl.cppgen.Std;
+import org.xtuml.masl.cppgen.TypeUsage;
+import org.xtuml.masl.cppgen.Variable;
+import org.xtuml.masl.cppgen.VariableDefinitionStatement;
+import org.xtuml.masl.cppgen.Visibility;
+import org.xtuml.masl.metamodel.common.ParameterDefinition;
+import org.xtuml.masl.metamodel.common.ParameterDefinition.Mode;
+import org.xtuml.masl.metamodel.domain.DomainTerminatorService;
+import org.xtuml.masl.metamodel.type.BasicType;
+import org.xtuml.masl.metamodel.type.TypeDefinition.ActualType;
+import org.xtuml.masl.metamodelImpl.type.StringType;
+import org.xtuml.masl.translate.main.Mangler;
+import org.xtuml.masl.translate.main.NlohmannJson;
+import org.xtuml.masl.translate.main.ParameterTranslator;
+import org.xtuml.masl.translate.main.TerminatorServiceTranslator;
+import org.xtuml.masl.translate.main.Types;
+
+public class DomainTerminatorServiceTranslator extends ServiceTranslator {
+
+    private final CodeFile codeFile;
+
+    private Function acceptFn;
+    private Variable consumer;
+    private Function overrider;
+    private Variable register;
+    private Class consumerClass;
+
+    DomainTerminatorServiceTranslator(DomainTerminatorService service, DomainTranslator domainTranslator,
+            CodeFile codeFile) {
+        super(service, domainTranslator);
+        this.codeFile = codeFile;
+    }
+
+    @Override
+    DomainTerminatorService getService() {
+        return (DomainTerminatorService) super.getService();
+    }
+
+    @Override
+    List<Runnable> getFilePopulators() {
+        return List.of(() -> codeFile.addClassDeclaration(consumerClass),
+                () -> codeFile.addVariableDefinition(consumer), () -> codeFile.addFunctionDefinition(acceptFn),
+                () -> codeFile.addFunctionDefinition(overrider), () -> codeFile.addVariableDefinition(register));
+    }
+
+    @Override
+    void translate() {
+
+        // if the service has a single string parameter, just pass through without
+        // parsing JSON
+        final boolean noParseJson = getService().getParameters().size() == 1
+                && getService().getParameters().get(0).getType().isAssignableFrom(StringType.createAnonymous());
+
+        // create and add the consumer class to the file
+        consumerClass = new Class(Mangler.mangleName(getService()) + "Consumer", getDomainNamespace());
+        consumerClass.addSuperclass(Kafka.dataConsumerClass, Visibility.PUBLIC);
+        final DeclarationGroup functions = consumerClass.createDeclarationGroup();
+
+        // create the constructor
+        final Function constructor = consumerClass.createConstructor(functions, Visibility.PUBLIC);
+        constructor.declareInClass(true);
+
+        // create the accept function
+        acceptFn = consumerClass.createMemberFunction(functions, "accept", Visibility.PUBLIC);
+        final Expression data = acceptFn.createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "data")
+                .asExpression();
+        acceptFn.setConst(true);
+        final Predicate<BasicType> typeIsSerializable = paramType -> !(paramType.getBasicType()
+                .getActualType() == ActualType.EVENT || paramType.getBasicType().getActualType() == ActualType.DEVICE
+                || paramType.getBasicType().getActualType() == ActualType.ANY_INSTANCE);
+        final Variable paramJson = new Variable(new TypeUsage(NlohmannJson.json), "params", NlohmannJson.parse(data));
+        if (!noParseJson && getService().getParameters().stream().map(p -> p.getType().getBasicType())
+                .anyMatch(typeIsSerializable)) {
+            // Only build a JSON object if it will be used
+            acceptFn.getCode().appendStatement(new VariableDefinitionStatement(paramJson));
+        }
+
+        // create the overrider function
+        overrider = new Function(Mangler.mangleName(getService()), getDomainNamespace());
+        overrider.setReturnType(Types.getInstance().getType(getService().getReturnType()));
+
+        final List<Expression> consumerArgs = new ArrayList<>();
+        final DeclarationGroup vars = consumerClass.createDeclarationGroup();
+        for (final ParameterDefinition param : getService().getParameters()) {
+            final TypeUsage type = Types.getInstance().getType(param.getType());
+
+            // add the parameter to the overrider function
+            final ParameterTranslator paramTrans = new ParameterTranslator(param, overrider);
+
+            // only process "out" parameters
+            if (param.getMode() == Mode.OUT) {
+
+                // capture each parameter as a member variable
+                final Variable constructorParam = constructor.createParameter(type.getReferenceType(),
+                        Mangler.mangleName(param));
+                final Variable memberVar = consumerClass.createMemberVariable(vars, Mangler.mangleName(param),
+                        type.getReferenceType(), Visibility.PRIVATE);
+                constructor.setInitialValue(memberVar, constructorParam.asExpression());
+
+                // parse out each parameter and assign it to the member variable
+                if (typeIsSerializable.test(param.getType().getBasicType())) {
+                    Expression paramAccess = Std.string.callConstructor(
+                            new Function("begin").asFunctionCall(data, false),
+                            new Function("end").asFunctionCall(data, false));
+                    if (!noParseJson) {
+                        paramAccess = NlohmannJson
+                                .get(getService().getParameters().size() > 1
+                                        ? new ArrayAccess(paramJson.asExpression(),
+                                                Literal.createStringLiteral(param.getName()))
+                                        : paramJson.asExpression(), type);
+                    }
+                    acceptFn.getCode().appendStatement(
+                            new BinaryExpression(memberVar.asExpression(), BinaryOperator.ASSIGN, paramAccess)
+                                    .asStatement());
+                }
+
+                // add to the list for the consumer call
+                consumerArgs.add(paramTrans.getVariable().asExpression());
+            }
+        }
+
+        // create consumer instance
+        consumer = new Variable(new TypeUsage(Kafka.consumerClass), "consumer_" + Mangler.mangleName(getService()),
+                getDomainNamespace(),
+                Kafka.consumerClass.callConstructor(Std.string.callConstructor(getTopicName(getService()))));
+
+        // add the call to consume to the overrider
+        final Variable dataConsumer = new Variable(new TypeUsage(consumerClass), "dataConsumer",
+                consumerClass.callConstructor(consumerArgs));
+        overrider.getCode().appendStatement(new VariableDefinitionStatement(dataConsumer));
+        overrider.getCode().appendStatement(new ReturnStatement(new Function("consumeOne")
+                .asFunctionCall(consumer.asExpression(), false, dataConsumer.asExpression())));
+
+        // register the overrider function
+        register = new Variable(new TypeUsage(FundamentalType.BOOL), "register_" + Mangler.mangleName(getService()),
+                getDomainNamespace(), TerminatorServiceTranslator.getInstance(getService()).getRegisterOverride()
+                        .asFunctionCall(overrider.asFunctionPointer()));
+    }
+}

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/DomainTranslator.java
@@ -1,5 +1,6 @@
 package org.xtuml.masl.translate.kafka;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,101 +9,91 @@ import org.xtuml.masl.cppgen.Library;
 import org.xtuml.masl.cppgen.Namespace;
 import org.xtuml.masl.cppgen.SharedLibrary;
 import org.xtuml.masl.metamodel.domain.Domain;
-import org.xtuml.masl.metamodel.type.TypeDeclaration;
+import org.xtuml.masl.metamodelImpl.type.BooleanType;
 import org.xtuml.masl.translate.Alias;
 import org.xtuml.masl.translate.Default;
 import org.xtuml.masl.translate.main.Mangler;
 
-
 @Alias("Kafka")
 @Default
-public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator
-{
+public class DomainTranslator extends org.xtuml.masl.translate.DomainTranslator {
 
-  public static final String KAFKA_TOPIC_PRAGMA = "kafka_topic";
-  public static final String KAFKA_PARTITION_KEY_PRAGMA = "kafka_partition_key";
+    public static final String KAFKA_TOPIC_PRAGMA = "kafka_topic";
+    public static final String KAFKA_PARTITION_KEY_PRAGMA = "kafka_partition_key";
 
-  private final org.xtuml.masl.translate.main.DomainTranslator mainTranslator;
-  private final Namespace domainNamespace;
-  private final Library library;
-  private final Library interfaceLibrary;
+    private final org.xtuml.masl.translate.main.DomainTranslator mainTranslator;
+    private final Namespace domainNamespace;
+    private final Library library;
+    private final Library interfaceLibrary;
 
-  public static DomainTranslator getInstance ( final Domain domain )
-  {
-    return getInstance(DomainTranslator.class, domain);
-  }
-
-  private DomainTranslator ( final Domain domain )
-  {
-    super(domain);
-    mainTranslator = org.xtuml.masl.translate.main.DomainTranslator.getInstance(domain);
-    domainNamespace = new Namespace(Mangler.mangleName(domain), Kafka.kafkaNamespace);
-
-
-    library = new SharedLibrary(mainTranslator.getLibrary().getName() + "_kafka").inBuildSet(mainTranslator.getBuildSet()).withCCDefaultExtensions();
-    library.addDependency(Kafka.library);
-    library.addDependency(Kafka.cppkafkaLibrary);
-    library.addDependency(Kafka.rdkafkaLibrary);
-
-    interfaceLibrary = new SharedLibrary(mainTranslator.getLibrary().getName() + "_if_kafka").inBuildSet(mainTranslator.getBuildSet()).withCCDefaultExtensions();
-    interfaceLibrary.addDependency(Kafka.library);
-    interfaceLibrary.addDependency(Kafka.cppkafkaLibrary);
-    interfaceLibrary.addDependency(Kafka.rdkafkaLibrary);
-  }
-
-  @Override
-  public void translate ()
-  {
-    // create code files
-    final CodeFile consumerCodeFile = library.createBodyFile("Kafka" + Mangler.mangleFile(domain));
-    final CodeFile publisherCodeFile = interfaceLibrary.createBodyFile("Kafka_publishers" + Mangler.mangleFile(domain));
-
-    // create service translators
-    final List<ServiceTranslator> serviceTranslators = domain.getServices().stream()
-      .filter(service -> service.getDeclarationPragmas().hasPragma(KAFKA_TOPIC_PRAGMA) && !service.isFunction() && !service.isExternal() && !service.isScenario())
-      .map(service -> new ServiceTranslator(service, this)).collect(Collectors.toList());
-
-
-    // translate service handlers
-    for (final ServiceTranslator serviceTranslator : serviceTranslators)
-    {
-      serviceTranslator.addServiceHandler(consumerCodeFile);
+    public static DomainTranslator getInstance(final Domain domain) {
+        return getInstance(DomainTranslator.class, domain);
     }
 
-    // handle custom topics (consumer)
-    for (final ServiceTranslator serviceTranslator : serviceTranslators)
-    {
-      serviceTranslator.addCustomTopicName(consumerCodeFile);
+    private DomainTranslator(final Domain domain) {
+        super(domain);
+        mainTranslator = org.xtuml.masl.translate.main.DomainTranslator.getInstance(domain);
+        domainNamespace = new Namespace(Mangler.mangleName(domain), Kafka.kafkaNamespace);
+
+        library = new SharedLibrary(mainTranslator.getLibrary().getName() + "_kafka")
+                .inBuildSet(mainTranslator.getBuildSet()).withCCDefaultExtensions();
+        library.addDependency(Kafka.library);
+        library.addDependency(Kafka.cppkafkaLibrary);
+        library.addDependency(Kafka.rdkafkaLibrary);
+
+        interfaceLibrary = new SharedLibrary(mainTranslator.getLibrary().getName() + "_if_kafka")
+                .inBuildSet(mainTranslator.getBuildSet()).withCCDefaultExtensions();
+        interfaceLibrary.addDependency(Kafka.library);
+        interfaceLibrary.addDependency(Kafka.cppkafkaLibrary);
+        interfaceLibrary.addDependency(Kafka.rdkafkaLibrary);
     }
 
-    // add topic registrations
-    for (final ServiceTranslator serviceTranslator : serviceTranslators)
-    {
-      serviceTranslator.addTopicRegistration(consumerCodeFile);
+    @Override
+    public void translate() {
+        // create code files
+        final CodeFile consumerCodeFile = library.createBodyFile("Kafka_consumers" + Mangler.mangleFile(domain));
+        final CodeFile pollerCodeFile = library.createBodyFile("Kafka_pollers" + Mangler.mangleFile(domain));
+        final CodeFile publisherCodeFile = interfaceLibrary
+                .createBodyFile("Kafka_publishers" + Mangler.mangleFile(domain));
+
+        // create domain service translators
+        final List<DomainServiceTranslator> domainServiceTranslators = domain.getServices().stream()
+                .filter(service -> service.getDeclarationPragmas().hasPragma(KAFKA_TOPIC_PRAGMA)
+                        && !service.isFunction() && !service.isExternal() && !service.isScenario())
+                .map(service -> new DomainServiceTranslator(service, this, consumerCodeFile, publisherCodeFile))
+                .collect(Collectors.toList());
+
+        // translate domain service handlers
+        domainServiceTranslators.forEach(DomainServiceTranslator::translate);
+
+        // populate the code for the domain services
+        List<Iterator<Runnable>> domainServiceFilePopulators = domainServiceTranslators.stream()
+                .map(ServiceTranslator::getFilePopulators).map(List::iterator).collect(Collectors.toList());
+        while (domainServiceFilePopulators.stream().anyMatch(Iterator::hasNext)) {
+            domainServiceFilePopulators.stream().filter(Iterator::hasNext).map(Iterator::next).forEach(Runnable::run);
+        }
+
+        // create domain terminator service translators
+        final List<DomainTerminatorServiceTranslator> terminatorServiceTranslators = domain.getTerminators().stream()
+                .flatMap(terminator -> terminator.getServices().stream())
+                .filter(service -> service.getDeclarationPragmas().hasPragma(KAFKA_TOPIC_PRAGMA) && service.isFunction()
+                        && service.getReturnType().isAssignableFrom(BooleanType.createAnonymous()))
+                .map(service -> new DomainTerminatorServiceTranslator(service, this, pollerCodeFile))
+                .collect(Collectors.toList());
+
+        // translate domain terminator service handlers
+        terminatorServiceTranslators.forEach(DomainTerminatorServiceTranslator::translate);
+
+        // populate the code for the terminator services
+        List<Iterator<Runnable>> terminatorServiceFilePopulators = terminatorServiceTranslators.stream()
+                .map(ServiceTranslator::getFilePopulators).map(List::iterator).collect(Collectors.toList());
+        while (terminatorServiceFilePopulators.stream().anyMatch(Iterator::hasNext)) {
+            terminatorServiceFilePopulators.stream().filter(Iterator::hasNext).map(Iterator::next)
+                    .forEach(Runnable::run);
+        }
     }
 
-    // create publisher services
-    for (final ServiceTranslator serviceTranslator : serviceTranslators)
-    {
-      serviceTranslator.addPublisher(publisherCodeFile);
+    Namespace getNamespace() {
+        return domainNamespace;
     }
-
-    // handle custom topics (publisher)
-    for (final ServiceTranslator serviceTranslator : serviceTranslators)
-    {
-      serviceTranslator.addCustomTopicName(publisherCodeFile);
-    }
-
-  }
-
-  Namespace getNamespace()
-  {
-    return domainNamespace;
-  }
-
-  org.xtuml.masl.translate.main.DomainTranslator getMainTranslator()
-  {
-    return mainTranslator;
-  }
-
 }

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/Kafka.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/Kafka.java
@@ -8,23 +8,23 @@ import org.xtuml.masl.cppgen.Library;
 import org.xtuml.masl.cppgen.Namespace;
 import org.xtuml.masl.translate.main.Architecture;
 
+public class Kafka {
 
-public class Kafka
-{
+    static Namespace kafkaNamespace = new Namespace("Kafka");
+    static Library library = new InterfaceLibrary("Kafka").inBuildSet(Architecture.buildSet);
+    static Library cppkafkaLibrary = new ImportedLibrary("cppkafka");
+    static Library rdkafkaLibrary = new ImportedLibrary("rdkafka");
 
-  static Namespace kafkaNamespace            = new Namespace("Kafka");
-  static Library   library                   = new InterfaceLibrary("Kafka").inBuildSet(Architecture.buildSet);
-  static Library   cppkafkaLibrary           = new ImportedLibrary("cppkafka");
-  static Library   rdkafkaLibrary            = new ImportedLibrary("rdkafka");
+    static CodeFile processHandlerInc = library.createInterfaceHeader("kafka/ProcessHandler.hh");
+    static CodeFile producerInc = library.createInterfaceHeader("kafka/Producer.hh");
+    static CodeFile serviceHandlerInc = library.createInterfaceHeader("kafka/ServiceHandler.hh");
+    static CodeFile dataConsumerInc = library.createInterfaceHeader("kafka/DataConsumer.hh");
+    static CodeFile consumerInc = library.createInterfaceHeader("kafka/Consumer.hh");
 
-  static CodeFile  bufferedIOInc             = library.createInterfaceHeader("kafka/BufferedIO.hh");
-  static CodeFile  processHandlerInc         = library.createInterfaceHeader("kafka/ProcessHandler.hh");
-  static CodeFile  producerInc               = library.createInterfaceHeader("kafka/Producer.hh");
-  static CodeFile  serviceHandlerInc         = library.createInterfaceHeader("kafka/ServiceHandler.hh");
-
-  static Class     processHandlerClass       = new Class("ProcessHandler", kafkaNamespace, processHandlerInc);
-  static Class     producerClass             = new Class("Producer", kafkaNamespace, producerInc);
-  static Class     callable                  = new Class("Callable", kafkaNamespace, processHandlerInc);
-  static Class     serviceHandlerClass       = new Class("ServiceHandler", kafkaNamespace, serviceHandlerInc);
-
+    static Class processHandlerClass = new Class("ProcessHandler", kafkaNamespace, processHandlerInc);
+    static Class producerClass = new Class("Producer", kafkaNamespace, producerInc);
+    static Class callable = new Class("Callable", kafkaNamespace, processHandlerInc);
+    static Class serviceHandlerClass = new Class("ServiceHandler", kafkaNamespace, serviceHandlerInc);
+    static Class dataConsumerClass = new Class("DataConsumer", kafkaNamespace, dataConsumerInc);
+    static Class consumerClass = new Class("Consumer", kafkaNamespace, consumerInc);
 }

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/ServiceTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/ServiceTranslator.java
@@ -1,243 +1,82 @@
 package org.xtuml.masl.translate.kafka;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import org.xtuml.masl.cppgen.ArrayAccess;
-import org.xtuml.masl.cppgen.BinaryExpression;
-import org.xtuml.masl.cppgen.BinaryOperator;
-import org.xtuml.masl.cppgen.Class;
-import org.xtuml.masl.cppgen.CodeFile;
-import org.xtuml.masl.cppgen.DeclarationGroup;
 import org.xtuml.masl.cppgen.Expression;
-import org.xtuml.masl.cppgen.ExpressionStatement;
 import org.xtuml.masl.cppgen.Function;
-import org.xtuml.masl.cppgen.FunctionObjectCall;
-import org.xtuml.masl.cppgen.FundamentalType;
 import org.xtuml.masl.cppgen.Literal;
 import org.xtuml.masl.cppgen.Namespace;
-import org.xtuml.masl.cppgen.NewExpression;
-import org.xtuml.masl.cppgen.ReturnStatement;
-import org.xtuml.masl.cppgen.Std;
-import org.xtuml.masl.cppgen.TypeUsage;
-import org.xtuml.masl.cppgen.TypedefType;
-import org.xtuml.masl.cppgen.Variable;
-import org.xtuml.masl.cppgen.VariableDefinitionStatement;
-import org.xtuml.masl.cppgen.Visibility;
-import org.xtuml.masl.metamodel.common.ParameterDefinition;
-import org.xtuml.masl.metamodel.domain.DomainService;
+import org.xtuml.masl.metamodel.common.Service;
+import org.xtuml.masl.metamodel.domain.DomainTerminatorService;
 import org.xtuml.masl.metamodel.type.BasicType;
 import org.xtuml.masl.metamodel.type.TypeDefinition.ActualType;
-import org.xtuml.masl.metamodelImpl.common.PragmaDefinition;
 import org.xtuml.masl.metamodelImpl.type.StringType;
 import org.xtuml.masl.translate.main.Architecture;
-import org.xtuml.masl.translate.main.DomainServiceTranslator;
-import org.xtuml.masl.translate.main.Mangler;
-import org.xtuml.masl.translate.main.NlohmannJson;
-import org.xtuml.masl.translate.main.ParameterTranslator;
-import org.xtuml.masl.translate.main.Types;
+import org.xtuml.masl.translate.main.TerminatorServiceTranslator;
 
+abstract class ServiceTranslator {
 
-class ServiceTranslator
-{
+    private final Service service;
+    private final DomainTranslator domainTranslator;
 
-  private final DomainService service;
-  private final DomainTranslator domainTranslator;
-  private final Class handlerClass;
-  private final Namespace domainNamespace;
-
-  ServiceTranslator ( final DomainService service, final DomainTranslator domainTranslator )
-  {
-    this.service = service;
-    this.domainTranslator = domainTranslator;
-    domainNamespace = domainTranslator.getNamespace();
-    handlerClass = new Class(Mangler.mangleName(service) + "Handler", domainNamespace);
-  }
-
-  void addServiceHandler (final CodeFile codeFile)
-  {
-    // create and add the handler class to the file
-    handlerClass.addSuperclass(Kafka.serviceHandlerClass, Visibility.PUBLIC);
-    final DeclarationGroup group = handlerClass.createDeclarationGroup();
-    final Function getInvoker = handlerClass.createMemberFunction(group, "getInvoker", Visibility.PUBLIC);
-    getInvoker.setReturnType(new TypeUsage(Kafka.callable));
-    getInvoker.setConst(true);
-    codeFile.addClassDeclaration(handlerClass);
-
-    // create the invoker class
-    final Class invokerClass = new Class(Mangler.mangleName(service) + "Invoker", domainNamespace);
-    final DeclarationGroup functions = invokerClass.createDeclarationGroup();
-    final Function constructor = invokerClass.createConstructor(functions, Visibility.PUBLIC);
-    constructor.declareInClass(true);
-    final Expression paramData = constructor.createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "param_data").asExpression();
-
-    // create invoker function
-    final Function invoker = invokerClass.createMemberFunction(functions, "operator()", Visibility.PUBLIC);
-    invoker.declareInClass(true);
-
-    // if the service has a single string parameter, just pass through
-    final boolean noParseJson = service.getParameters().size() == 1 && service.getParameters().get(0).getType().isAssignableFrom(StringType.createAnonymous());
-
-    // handle parameters
-    final List<Expression> invokeArgs = new ArrayList<Expression>();
-    final DeclarationGroup vars = invokerClass.createDeclarationGroup();
-    final Variable paramJson = new Variable(new TypeUsage(NlohmannJson.json), "params", NlohmannJson.parse(paramData));
-    if (service.getParameters().stream().map(p -> p.getType().getBasicType()).anyMatch(paramType ->
-        !(paramType.getBasicType().getActualType() == ActualType.EVENT ||
-          paramType.getBasicType().getActualType() == ActualType.DEVICE || paramType.getBasicType().getActualType() == ActualType.ANY_INSTANCE)) && !noParseJson) {
-        constructor.getCode().appendStatement(new VariableDefinitionStatement(paramJson));
+    ServiceTranslator(final Service service, final DomainTranslator domainTranslator) {
+        this.service = service;
+        this.domainTranslator = domainTranslator;
     }
-    for ( final ParameterDefinition param : service.getParameters() )
-    {
-      final TypeUsage type = Types.getInstance().getType(param.getType());
-      final BasicType paramType = param.getType().getBasicType();
-      if (!(paramType.getBasicType().getActualType() == ActualType.EVENT ||
-          paramType.getBasicType().getActualType() == ActualType.DEVICE || paramType.getBasicType().getActualType() == ActualType.ANY_INSTANCE))
-      {
-        final Variable arg = invokerClass.createMemberVariable(vars, Mangler.mangleName(param), type, Visibility.PRIVATE);
-        Expression paramAccess = Std.string.callConstructor(new Function("begin").asFunctionCall(paramData, false), new Function("end").asFunctionCall(paramData, false));
-        if (!noParseJson) {
-          paramAccess = NlohmannJson.get(service.getParameters().size() > 1 ? new ArrayAccess(paramJson.asExpression(), Literal.createStringLiteral(param.getName())) : paramJson.asExpression(), type);
+
+    abstract void translate();
+
+    abstract List<Runnable> getFilePopulators();
+
+    Service getService() {
+        return service;
+    }
+
+    DomainTranslator getDomainTranslator() {
+        return domainTranslator;
+    }
+
+    Namespace getDomainNamespace() {
+        return getDomainTranslator().getNamespace();
+    }
+
+    Expression getTopicName(final DomainTerminatorService service) {
+        if (service.getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_TOPIC_PRAGMA).size() == 1) {
+            final String topicNameString = service.getDeclarationPragmas()
+                    .getPragmaValues(DomainTranslator.KAFKA_TOPIC_PRAGMA).get(0);
+            if (!isBoolean(topicNameString) && !isNumeric(topicNameString)) {
+                return Literal.createStringLiteral(topicNameString);
+            }
         }
-        constructor.getCode().appendStatement(new BinaryExpression(arg.asExpression(), BinaryOperator.ASSIGN, paramAccess).asStatement());
-        invokeArgs.add(arg.asExpression());
-      }
-      else
-      {
-        final Variable arg = new Variable(type, Mangler.mangleName(param));
-        invoker.getCode().appendStatement(arg.asStatement());
-        invokeArgs.add(arg.asExpression());
-      }
-    }
-
-    // create the call to the service interceptor
-    final DomainServiceTranslator serviceTranslator = DomainServiceTranslator.getInstance(service);
-    final TypedefType serviceInterceptor = serviceTranslator.getServiceInterceptor();
-    final Function serviceFunction = new Function("callService");
-    final Expression instanceFnCall = serviceInterceptor.asClass().callStaticFunction("instance");
-    Expression invokeExpression = new FunctionObjectCall(serviceFunction.asFunctionCall(instanceFnCall, false), invokeArgs);
-    invoker.getCode().appendStatement(invokeExpression.asStatement());
-
-    // add the invoker class to the file
-    codeFile.addClassDeclaration(invokerClass);
-
-    // add implementation of 'getInvoker' to the file
-    final Expression paramData2 = getInvoker.createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "param_data").asExpression();
-    getInvoker.getCode().appendStatement(new ReturnStatement(invokerClass.callConstructor(paramData2)));
-    codeFile.addFunctionDefinition(getInvoker);
-
-  }
-
-  void addTopicRegistration(final CodeFile codeFile)
-  {
-    final Expression processHandler = Kafka.processHandlerClass.callStaticFunction("getInstance");
-    final Expression domainId = new Function("getId").asFunctionCall(new Function("getDomain").asFunctionCall(Architecture.process, false, Literal.createStringLiteral(domainTranslator.getDomain().getName())), false);
-    final Expression serviceId = domainTranslator.getMainTranslator().getServiceTranslator(service).getServiceId();
-    final Expression handler = Std.shared_ptr(new TypeUsage(handlerClass)).callConstructor(new NewExpression(new TypeUsage(handlerClass)));
-    final Function registerServiceFunc = new Function("registerServiceHandler");
-    final Expression registerService = registerServiceFunc.asFunctionCall(processHandler, false, domainId, serviceId, handler);
-    final Variable registered = new Variable(new TypeUsage(FundamentalType.BOOL), Mangler.mangleName(service) + "_registered", new Namespace(""), registerService);
-    codeFile.addVariableDefinition(registered);
-  }
-
-  void addPublisher(final CodeFile codeFile)
-  {
-    // create service function
-    final Function function = new Function(Mangler.mangleName(service), domainNamespace);
-    function.setReturnType(domainTranslator.getTypes().getType(service.getReturnType()));
-
-    // if the service has a single string parameter, just pass through
-    final boolean noParseJson = service.getParameters().size() == 1 && StringType.createAnonymous().isAssignableFrom(service.getParameters().get(0).getType());
-
-    // create output buffer
-    final Variable paramData = new Variable(new TypeUsage(NlohmannJson.json), "param_data");
-    if (!noParseJson) {
-        function.getCode().appendStatement(new VariableDefinitionStatement(paramData));
-    }
-
-    // create partition key buffer
-    final Variable partKey = new Variable(new TypeUsage(NlohmannJson.json), "part_key");
-    final boolean includePartKey = service.getParameters().stream().anyMatch(param -> service.getDeclarationPragmas().hasPragma(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA) &&
-        service.getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA).contains(param.getName()));
-    if (includePartKey) {
-        function.getCode().appendStatement(new VariableDefinitionStatement(partKey));
-    }
-
-    // handle parameters
-    final Map<ParameterDefinition, ParameterTranslator> paramTranslators = new HashMap<>();
-    for ( final ParameterDefinition param : service.getParameters() )
-    {
-      final ParameterTranslator paramTrans = new ParameterTranslator(param, function);
-      paramTranslators.put(param, paramTrans);
-      final Expression jsonAccess = service.getParameters().size() > 1 ? new ArrayAccess(paramData.asExpression(), Literal.createStringLiteral(param.getName())) : paramData.asExpression();
-      final Expression writeExpr = new BinaryExpression(jsonAccess, BinaryOperator.ASSIGN, paramTrans.getVariable().asExpression());
-      if (!noParseJson) {
-          function.getCode().appendStatement(new ExpressionStatement(writeExpr));
-      }
-      if ( service.getDeclarationPragmas().hasPragma(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA) &&
-          service.getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA).contains(param.getName()) )
-      {
-        final Expression keyJsonAccess = service.getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_PARTITION_KEY_PRAGMA).size() > 1 ? new ArrayAccess(partKey.asExpression(), Literal.createStringLiteral(param.getName())) : partKey.asExpression();
-        final Expression keyWriteExpr = new BinaryExpression(keyJsonAccess, BinaryOperator.ASSIGN, paramTrans.getVariable().asExpression());
-        function.getCode().appendStatement(new ExpressionStatement(keyWriteExpr));
-      }
-    }
-
-    // call publisher
-    final Expression producer = Kafka.producerClass.callStaticFunction("getInstance");
-    final Function publishFunc = new Function("publish");
-    final Expression domainId = new Function("getId").asFunctionCall(new Function("getDomain").asFunctionCall(Architecture.process, false, Literal.createStringLiteral(domainTranslator.getDomain().getName())), false);
-    final Expression serviceId = domainTranslator.getMainTranslator().getServiceTranslator(service).getServiceId();
-    final Expression publishExpr = publishFunc.asFunctionCall(producer, false, domainId, serviceId, noParseJson ?
-        Std.string.callConstructor(paramTranslators.get(service.getParameters().get(0)).getVariable().asExpression()) :
-        NlohmannJson.dump(paramData.asExpression()),
-        includePartKey ? NlohmannJson.dump(partKey.asExpression()) : Literal.createStringLiteral(""));
-    function.getCode().appendStatement(new ExpressionStatement(publishExpr));
-
-    // add function to file
-    codeFile.addFunctionDefinition(function);
-
-    // add service registration
-    final DomainServiceTranslator serviceTranslator = DomainServiceTranslator.getInstance(service);
-    final TypedefType serviceInterceptor = serviceTranslator.getServiceInterceptor();
-    final Expression interceptorFnCall = serviceInterceptor.asClass().callStaticFunction("instance");
-    final Function registerFunction = new Function("registerLocal");
-    final Expression initialValue = registerFunction.asFunctionCall(interceptorFnCall, false, function.asFunctionPointer());
-    final Variable registrationVar = new Variable(new TypeUsage(FundamentalType.BOOL, TypeUsage.Const), "localServiceRegistration_" + Mangler.mangleName(service), domainNamespace, initialValue);
-    registrationVar.setStatic(true);
-    codeFile.addVariableDefinition(registrationVar);
-
-  }
-
-  void addCustomTopicName(final CodeFile codeFile) {
-    if (service.getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_TOPIC_PRAGMA).size() == 1) {
-      final String topicNameString = service.getDeclarationPragmas().getPragmaValues(DomainTranslator.KAFKA_TOPIC_PRAGMA).get(0);
-      if (!isBoolean(topicNameString) && !isNumeric(topicNameString)) {
         final Expression processHandler = Kafka.processHandlerClass.callStaticFunction("getInstance");
-        final Expression domainId = new Function("getId").asFunctionCall(new Function("getDomain").asFunctionCall(Architecture.process, false, Literal.createStringLiteral(domainTranslator.getDomain().getName())), false);
-        final Expression serviceId = domainTranslator.getMainTranslator().getServiceTranslator(service).getServiceId();
-        final Expression topicName = Literal.createStringLiteral(topicNameString);
-        final Function setTopicNameFunc = new Function("setCustomTopicName");
-        final Expression setTopicName = setTopicNameFunc.asFunctionCall(processHandler, false, domainId, serviceId, topicName);
-        final Variable topicNameSet = new Variable(new TypeUsage(FundamentalType.BOOL), Mangler.mangleName(service) + "_topic_name_set", new Namespace(""), setTopicName);
-        codeFile.addVariableDefinition(topicNameSet);
-      }
+        final Expression domainId = new Function("getId")
+                .asFunctionCall(new Function("getDomain").asFunctionCall(Architecture.process, false,
+                        Literal.createStringLiteral(getDomainTranslator().getDomain().getName())), false);
+        final Expression serviceId = TerminatorServiceTranslator.getInstance(service).getServiceId();
+        return new Function("getTopicName").asFunctionCall(processHandler, false, domainId, serviceId);
     }
-  }
 
-  private boolean isBoolean(final String value) {
-    return "true".equals(value) || "false".equals(value);
-  }
-
-  private boolean isNumeric(final String value) {
-    try {
-      double d = Double.parseDouble(value);
-      return true;
-    } catch (NumberFormatException e) {
-      return false;
+    static boolean isBoolean(final String value) {
+        return "true".equals(value) || "false".equals(value);
     }
-  }
 
+    static boolean isNumeric(final String value) {
+        try {
+            Double.parseDouble(value);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    static boolean hasSingleStringParameter(Service service) {
+        return service.getParameters().size() == 1
+                && service.getParameters().get(0).getType().isAssignableFrom(StringType.createAnonymous());
+    }
+
+    static boolean isTypeSerializable(BasicType type) {
+        return !(type.getBasicType().getActualType() == ActualType.EVENT
+                || type.getBasicType().getActualType() == ActualType.DEVICE
+                || type.getBasicType().getActualType() == ActualType.ANY_INSTANCE);
+    }
 }

--- a/core-java/src/main/java/org/xtuml/masl/translate/kafka/ServiceTranslator.java
+++ b/core-java/src/main/java/org/xtuml/masl/translate/kafka/ServiceTranslator.java
@@ -71,7 +71,7 @@ class ServiceTranslator
     final DeclarationGroup functions = invokerClass.createDeclarationGroup();
     final Function constructor = invokerClass.createConstructor(functions, Visibility.PUBLIC);
     constructor.declareInClass(true);
-    final Expression paramData = constructor.createParameter(new TypeUsage(Std.string), "param_data").asExpression();
+    final Expression paramData = constructor.createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "param_data").asExpression();
 
     // create invoker function
     final Function invoker = invokerClass.createMemberFunction(functions, "operator()", Visibility.PUBLIC);
@@ -97,7 +97,7 @@ class ServiceTranslator
           paramType.getBasicType().getActualType() == ActualType.DEVICE || paramType.getBasicType().getActualType() == ActualType.ANY_INSTANCE))
       {
         final Variable arg = invokerClass.createMemberVariable(vars, Mangler.mangleName(param), type, Visibility.PRIVATE);
-        Expression paramAccess = paramData;
+        Expression paramAccess = Std.string.callConstructor(new Function("begin").asFunctionCall(paramData, false), new Function("end").asFunctionCall(paramData, false));
         if (!noParseJson) {
           paramAccess = NlohmannJson.get(service.getParameters().size() > 1 ? new ArrayAccess(paramJson.asExpression(), Literal.createStringLiteral(param.getName())) : paramJson.asExpression(), type);
         }
@@ -124,7 +124,7 @@ class ServiceTranslator
     codeFile.addClassDeclaration(invokerClass);
 
     // add implementation of 'getInvoker' to the file
-    final Expression paramData2 = getInvoker.createParameter(new TypeUsage(Std.string), "param_data").asExpression();
+    final Expression paramData2 = getInvoker.createParameter(new TypeUsage(Std.vector(new TypeUsage(Std.uint8))), "param_data").asExpression();
     getInvoker.getCode().appendStatement(new ReturnStatement(invokerClass.callConstructor(paramData2)));
     codeFile.addFunctionDefinition(getInvoker);
 


### PR DESCRIPTION
Allow terminator services to be marked as a kafka topic.

Eligible terminator services must:
- return boolean
- carry only "out" parameters of serializable types

When a terminator service marked as a kafka topic is called, the architecture will poll the kafka broker for one message. If a message is available, it will attempt to parse out the individual parameters from the received JSON object and populate the "out" parameters. It will then return true. If no messages are available, it will leave the parameters unchanged and return false. If the message payload is not valid JSON or if the fields do not match the names and types of the parameters, an exception will be raised and the process will exit.

If the "-util Kafka" flag is not passed to the process on startup, the code in the local terminator service body will be executed.